### PR TITLE
Alternate homeserver login

### DIFF
--- a/fractal/matrix/async_client.py
+++ b/fractal/matrix/async_client.py
@@ -1,6 +1,8 @@
 import logging
 import os
 from typing import Any, Dict, List, Optional, Union, Tuple
+from urllib.parse import urlparse
+
 
 import aiohttp
 from aiofiles import open as aiofiles_open
@@ -20,6 +22,7 @@ from nio import (
     SyncError,
     TransferMonitor,
     UploadError,
+    DiscoveryInfoError, 
 )
 from nio.responses import RegisterErrorResponse
 
@@ -351,17 +354,17 @@ async def get_homeserver_for_matrix_id(matrix_id: str) -> Tuple[str, bool]:
     # FIXME: just because matrix_id has localhost, doesn't necessarily mean
     # that the homeserver is running on localhost. Could be synapse:8008, etc.
     if "localhost" in matrix_id:
-        homeserver_url = "http://localhost:8008"
+        homeserver_url = os.environ.get('MATRIX_HOMESERVER_URL', "http://localhost:8008")
     else:
         _, homeserver_host = parse_matrix_id(matrix_id)
         homeserver_url = f"https://{homeserver_host}"
     async with MatrixClient(homeserver_url) as client:
         res = await client.discovery_info()
-    if not res.transport_response.ok:  # type: ignore
+    if isinstance(res, DiscoveryInfoError):
         if res.transport_response.reason == "Not Found":  # type: ignore
-            raise WellKnownNotFoundException()  # type: ignore
+            raise WellKnownNotFoundException()  
         raise UnknownDiscoveryInfoException(res.transport_response.reason)  # type: ignore
-    if res.homeserver_url == homeserver_url: # type: ignore
-        return res.homeserver_url, False # type: ignore
+    if urlparse(homeserver_url).netloc in urlparse(res.homeserver_url).netloc: 
+        return res.homeserver_url, False 
     else:
-        return res.homeserver_url, True  # type: ignore
+        return res.homeserver_url, True  

--- a/fractal/matrix/async_client.py
+++ b/fractal/matrix/async_client.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Tuple
 
 import aiohttp
 from aiofiles import open as aiofiles_open
@@ -346,18 +346,22 @@ class MatrixClient:
         await self.client.close()
 
 
-async def get_homeserver_for_matrix_id(matrix_id: str) -> str:
+async def get_homeserver_for_matrix_id(matrix_id: str) -> Tuple[str, bool]:
     """Lookup the homeserver url associated with a Matrix ID"""
     # FIXME: just because matrix_id has localhost, doesn't necessarily mean
     # that the homeserver is running on localhost. Could be synapse:8008, etc.
     if "localhost" in matrix_id:
-        return "http://localhost:8008"
-    _, homeserver_host = parse_matrix_id(matrix_id)
-    homeserver_url = f"https://{homeserver_host}"
+        homeserver_url = "http://localhost:8008"
+    else:
+        _, homeserver_host = parse_matrix_id(matrix_id)
+        homeserver_url = f"https://{homeserver_host}"
     async with MatrixClient(homeserver_url) as client:
         res = await client.discovery_info()
     if not res.transport_response.ok:  # type: ignore
         if res.transport_response.reason == "Not Found":  # type: ignore
             raise WellKnownNotFoundException()  # type: ignore
         raise UnknownDiscoveryInfoException(res.transport_response.reason)  # type: ignore
-    return res.homeserver_url  # type: ignore
+    if res.homeserver_url == homeserver_url: # type: ignore
+        return res.homeserver_url, False # type: ignore
+    else:
+        return res.homeserver_url, True  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fractal-matrix-client"
-version = "0.0.2"
+version = "0.0.3"
 description = ""
 authors = ["Mo Balaa <balaa@fractalnetworks.co>"]
 readme = "README.md"


### PR DESCRIPTION
Added logic to determine if the homeserver that is returned by parse_matrix_id is the same that is returned by discorvery_info. Also cleaned up type:ignore comments.