### PR TITLE
Upload file test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import pytest
 from fractal.matrix.async_client import FractalAsyncClient
 
 
@@ -5,3 +6,17 @@ def test_fractal_async_client():
     test_object = FractalAsyncClient()
     print("work")
     return test_object
+
+
+@pytest.fixture()
+def mock_async_context_manager():
+    class AsyncContextManager:
+        async def __aenter__(self):
+            # Perform setup actions here
+            yield "async_context_value"
+
+        async def __aexit__(self, exc_type, exc, tb):
+            # Perform cleanup actions here
+            pass
+
+    return AsyncContextManager

--- a/fractal/matrix/async_client.py
+++ b/fractal/matrix/async_client.py
@@ -117,6 +117,8 @@ class FractalAsyncClient(AsyncClient):
         if not admin:
             raise Exception("FIXME: Only admin invites are supported for now.")
 
+        parse_matrix_id(user_id)
+
         # check if user_id is lowercase
         if not user_id.split("@")[1].islower():
             raise Exception("Matrix ids must be lowercase.")
@@ -270,6 +272,7 @@ class FractalAsyncClient(AsyncClient):
         Args:
             file_path (str): The path to the file to upload.
             monitor (Optional[TransferMonitor]): A transfer monitor to use. Defaults to None.
+            filename (Optional[str]): Uploads the file using this file name. Defaults to None.
 
         Returns:
             str: The content uri of the uploaded file.

--- a/tests/test_fractal_async_client_invite.py
+++ b/tests/test_fractal_async_client_invite.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fractal.matrix.async_client import FractalAsyncClient
+from fractal.matrix.exceptions import InvalidMatrixIdException
 from nio import (
     RoomGetStateEventError,
     RoomGetStateEventResponse,
@@ -59,9 +60,9 @@ async def test_invite_raise_exception_for_userID():
     sample_user_id = "sample_user:sample_domain"
     sample_room_id = "sample_id"
     client = FractalAsyncClient()
-    with pytest.raises(Exception) as e:
+    with pytest.raises(InvalidMatrixIdException) as e:
         await client.invite(user_id=sample_user_id, room_id=sample_room_id, admin=True)
-    assert "Expected UserID string to start with" in str(e.value)
+    assert f"{sample_user_id} is not a valid Matrix ID." in str(e.value)
 
 
 async def test_invite_get_power_levels():

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -273,7 +273,7 @@ async def test_register_with_token():
     client.register_with_token = AsyncMock()
 
 
-async def test_upload_file_logger(mock_async_context_manager):
+async def test_upload_file_success_no_monitor(mock_async_context_manager):
     client = FractalAsyncClient()
     success = (UploadResponse("http://Someurl"), {})
     client.upload = AsyncMock(return_value=success)
@@ -289,6 +289,7 @@ async def test_upload_file_logger(mock_async_context_manager):
                 assert content_uri == "http://Someurl"
                 mock_logger.info.assert_called_once_with(f"Uploading file: {file_path}")
                 client.upload.assert_called()
+                assert "monitor" not in client.upload.call_args.kwargs
 
 
 async def test_upload_file_uploaderror(mock_async_context_manager):
@@ -325,3 +326,5 @@ async def test_upload_file_monitor_success(mock_async_context_manager):
                 assert content_uri == "http://Someurl"
                 mock_logger.info.assert_called_once_with(f"Uploading file: {file_path}")
                 assert "http://Someurl" in content_uri
+                client.upload.assert_called()
+                assert client.upload.call_args.kwargs["monitor"].total_size == 10


### PR DESCRIPTION
Add full coverage for the fractal async clients upload file method.
Finished test_upload_file_monitor_success.
Changed test_upload_file_logger to test_upload_file_success_no_monitor and updated functionality accordingly.